### PR TITLE
chore: remove legacy docker-compose volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     volumes:
     - "/var/run/docker.sock:/var/run/docker.sock:ro"
     - "./:/plugins-local/src/github.com/taskmedia/ddns-allowlist:ro"
-    - "./dyn:/dyn"
 
   whoami:
     image: "traefik/whoami"


### PR DESCRIPTION
 `dyn` was used for some testing (traefik config dir) but not longer in use