### PR TITLE
fix: allow multiple IP to be allowed

### DIFF
--- a/ddnsallowlist.go
+++ b/ddnsallowlist.go
@@ -106,15 +106,20 @@ func (a *ddnsallowlist) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 	log.Debugf("request IP addresses: %v", reqIPs)
 
+	allowed := false
 	for _, reqIP := range reqIPs {
-		isAllowed := aIPs.contains(reqIP)
-
-		if !isAllowed {
-			log.Infof("request denied from %s, allowList: [%s]", reqIPs, aIPs.String())
-			reject(http.StatusForbidden, rw, log)
-			return
+		if aIPs.contains(reqIP) {
+			allowed = true
+			break
 		}
 	}
+
+	if !allowed {
+		log.Infof("request denied from %s, allowList: [%s]", reqIPs, aIPs.String())
+		reject(http.StatusForbidden, rw, log)
+		return
+	}
+
 	log.Infof("request allowed from %s, allowList: [%s]", reqIPs, aIPs.String())
 	a.next.ServeHTTP(rw, req)
 }

--- a/ddnsallowlist_test.go
+++ b/ddnsallowlist_test.go
@@ -157,6 +157,19 @@ func TestDdnsAllowlist_ServeHTTP(t *testing.T) {
 			},
 			expected: http.StatusOK,
 		},
+		{
+			// this case can happen if the loadbalancer is not forwarding the correct request IP but its local address
+			desc:     "access with multiple IPs",
+			hostList: []string{"dns.google"},
+			req: &http.Request{
+				RemoteAddr: "10.1.2.3",
+				Header: map[string][]string{
+					"X-Forwarded-For":  {"10.1.2.3"},
+					"Cf-Connecting-Ip": {"8.8.8.8"},
+				},
+			},
+			expected: http.StatusOK,
+		},
 	}
 
 	for _, test := range testCases {

--- a/ddnsallowlist_test.go
+++ b/ddnsallowlist_test.go
@@ -65,55 +65,69 @@ func TestDdnsAllowlist(t *testing.T) {
 
 func TestDdnsAllowlist_ServeHTTP(t *testing.T) {
 	testCases := []struct {
-		desc      string
-		hostList  []string
-		ipList    []string
-		reqIPAddr string
-		expected  int
+		desc     string
+		hostList []string
+		ipList   []string
+		req      *http.Request
+		expected int
 	}{
 		{
-			desc:      "allowed host internal - localhost",
-			hostList:  []string{"localhost"},
-			reqIPAddr: "127.0.0.1",
-			expected:  http.StatusOK,
+			desc:     "allowed host internal - localhost",
+			hostList: []string{"localhost"},
+			req: &http.Request{
+				RemoteAddr: "127.0.0.1",
+			},
+			expected: http.StatusOK,
 		},
 		{
-			desc:      "allowed host external - dns.google",
-			hostList:  []string{"dns.google"},
-			reqIPAddr: "8.8.8.8",
-			expected:  http.StatusOK,
+			desc:     "allowed host external - dns.google",
+			hostList: []string{"dns.google"},
+			req: &http.Request{
+				RemoteAddr: "8.8.8.8",
+			},
+			expected: http.StatusOK,
 		},
 		{
-			desc:      "denied host internal - localhost",
-			hostList:  []string{"localhost"},
-			reqIPAddr: "10.10.10.10",
-			expected:  http.StatusForbidden,
+			desc:     "denied host internal - localhost",
+			hostList: []string{"localhost"},
+			req: &http.Request{
+				RemoteAddr: "10.10.10.10",
+			},
+			expected: http.StatusForbidden,
 		},
 		{
-			desc:      "denied host external",
-			hostList:  []string{"localhost"},
-			reqIPAddr: "1.2.3.4",
-			expected:  http.StatusForbidden,
+			desc:     "denied host external",
+			hostList: []string{"localhost"},
+			req: &http.Request{
+				RemoteAddr: "1.2.3.4",
+			},
+			expected: http.StatusForbidden,
 		},
 		{
-			desc:      "invalid host list",
-			hostList:  []string{"invalid"},
-			reqIPAddr: "127.0.0.1",
-			expected:  http.StatusInternalServerError,
+			desc:     "invalid host list",
+			hostList: []string{"invalid"},
+			req: &http.Request{
+				RemoteAddr: "127.0.0.1",
+			},
+			expected: http.StatusInternalServerError,
 		},
 		{
-			desc:      "allowed ip",
-			hostList:  []string{"localhost"},
-			ipList:    []string{"1.2.3.4"},
-			reqIPAddr: "1.2.3.4",
-			expected:  http.StatusOK,
+			desc:     "allowed ip",
+			hostList: []string{"localhost"},
+			ipList:   []string{"1.2.3.4"},
+			req: &http.Request{
+				RemoteAddr: "1.2.3.4",
+			},
+			expected: http.StatusOK,
 		},
 		{
-			desc:      "invalid ip list",
-			hostList:  []string{"localhost"},
-			ipList:    []string{"invalid-ip"},
-			reqIPAddr: "127.0.0.1",
-			expected:  http.StatusInternalServerError,
+			desc:     "invalid ip list",
+			hostList: []string{"localhost"},
+			ipList:   []string{"invalid-ip"},
+			req: &http.Request{
+				RemoteAddr: "127.0.0.1",
+			},
+			expected: http.StatusInternalServerError,
 		},
 	}
 
@@ -135,12 +149,8 @@ func TestDdnsAllowlist_ServeHTTP(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotNil(t, handler)
 
-			req := &http.Request{
-				RemoteAddr: test.reqIPAddr,
-			}
-
 			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
+			handler.ServeHTTP(rec, test.req)
 
 			assert.Equal(t, test.expected, rec.Code)
 		})

--- a/ddnsallowlist_test.go
+++ b/ddnsallowlist_test.go
@@ -129,6 +129,34 @@ func TestDdnsAllowlist_ServeHTTP(t *testing.T) {
 			},
 			expected: http.StatusInternalServerError,
 		},
+		{
+			desc:     "access via IPv6",
+			hostList: []string{"localhost"},
+			req: &http.Request{
+				RemoteAddr: "::1",
+			},
+			expected: http.StatusOK,
+		},
+		{
+			desc:     "access via xForwardedFor IP only",
+			hostList: []string{"dns.google"},
+			req: &http.Request{
+				Header: map[string][]string{
+					"X-Forwarded-For": {"8.8.8.8"},
+				},
+			},
+			expected: http.StatusOK,
+		},
+		{
+			desc:     "access via Cloudflare IP only",
+			hostList: []string{"dns.google"},
+			req: &http.Request{
+				Header: map[string][]string{
+					"Cf-Connecting-Ip": {"8.8.8.8"},
+				},
+			},
+			expected: http.StatusOK,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
This changes allowes if multiple requester IPs are given that any IP will allow the request. Before this change only the first IP was checked.

Also adding more tests (IPv6) and headers.