### PR TITLE
chore: change allow log msg to debug

### DIFF
--- a/ddnsallowlist.go
+++ b/ddnsallowlist.go
@@ -120,7 +120,7 @@ func (a *ddnsallowlist) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log.Infof("request allowed from %s, allowList: [%s]", reqIPs, aIPs.String())
+	log.Debugf("request allowed from %s, allowList: [%s]", reqIPs, aIPs.String())
 	a.next.ServeHTTP(rw, req)
 }
 


### PR DESCRIPTION
No need to log it as info when everything went as expected - only info log when denied