### PR TITLE
chore: use stdout directly without log pkg

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -49,7 +49,7 @@ func newLogger(_logLevel, middleware, middlewareType string) *Logger {
 		},
 		_info: func(args ...interface{}) {
 			prefixArgs := append([]interface{}{getTimestamp(), prefixInfo, ">"}, args...)
-			log.New(os.Stdout, "", 0).Println(prefixArgs...)
+			fmt.Fprintln(os.Stdout, prefixArgs...)
 		},
 		_error: func(args ...interface{}) {
 			log.Println(args...)
@@ -58,8 +58,8 @@ func newLogger(_logLevel, middleware, middlewareType string) *Logger {
 			fmt.Printf(format+"\n", args...)
 		},
 		_infof: func(format string, args ...interface{}) {
-			f := getTimestamp() + " " + prefixInfo + " > " + format
-			log.New(os.Stdout, "", 0).Printf(f, args...)
+			f := getTimestamp() + " " + prefixInfo + " > " + format + "\n"
+			fmt.Fprintf(os.Stdout, f, args...)
 		},
 		_errorf: func(format string, args ...interface{}) {
 			log.Printf(format+"\n", args...)

--- a/logger.go
+++ b/logger.go
@@ -49,6 +49,7 @@ func newLogger(_logLevel, middleware, middlewareType string) *Logger {
 		},
 		_info: func(args ...interface{}) {
 			prefixArgs := append([]interface{}{getTimestamp(), prefixInfo, ">"}, args...)
+			//nolint:errcheck
 			fmt.Fprintln(os.Stdout, prefixArgs...)
 		},
 		_error: func(args ...interface{}) {
@@ -59,6 +60,7 @@ func newLogger(_logLevel, middleware, middlewareType string) *Logger {
 		},
 		_infof: func(format string, args ...interface{}) {
 			f := getTimestamp() + " " + prefixInfo + " > " + format + "\n"
+			//nolint:errcheck
 			fmt.Fprintf(os.Stdout, f, args...)
 		},
 		_errorf: func(format string, args ...interface{}) {


### PR DESCRIPTION
Directly use `os.stdout` instead of calling `log.New()`