### PR TITLE
chore: add contenttype for rejected requests

### DIFF
--- a/ddnsallowlist.go
+++ b/ddnsallowlist.go
@@ -167,6 +167,7 @@ func (dal *ddnsAllowLister) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 }
 
 func reject(logger *Logger, statusCode int, rw http.ResponseWriter) {
+	rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	rw.WriteHeader(statusCode)
 	_, err := rw.Write([]byte(http.StatusText(statusCode)))
 	if err != nil {


### PR DESCRIPTION
Add `Content-Type` header to rejected message.
This might fix an issue on iOS (Chrome) when receiving an rejected resolved in a document to download.