### PR TITLE
chore: allow IPv6

### DIFF
--- a/ddnsallowlist.go
+++ b/ddnsallowlist.go
@@ -24,9 +24,9 @@ const (
 
 // Define static error variable.
 var (
-	errEmptySourceRangeHosts     = errors.New("sourceRangeHosts is empty, DDNSAllowLister not created")
-	errInvalidHTTPStatuscode     = errors.New("invalid HTTP status code")
-	errNoIPv4AddressFoundForHost = errors.New("no IPv4 addresses found for hostname")
+	errEmptySourceRangeHosts   = errors.New("sourceRangeHosts is empty, DDNSAllowLister not created")
+	errInvalidHTTPStatuscode   = errors.New("invalid HTTP status code")
+	errNoIPAddressFoundForHost = errors.New("no IP addresses found for hostname")
 )
 
 // DdnsAllowListConfig holds the DDNS allowlist middleware plugin configuration.
@@ -185,23 +185,15 @@ func resolveHosts(logger Logger, hosts []string) []string {
 
 		currentHostIPs := []string{}
 		for _, lookupIP := range lookupIPs {
-			// Currently only IPv4 is supported
-			if isIPv4(lookupIP) {
-				currentHostIPs = append(currentHostIPs, lookupIP.String())
-			}
+			currentHostIPs = append(currentHostIPs, lookupIP.String())
 		}
 
 		if len(currentHostIPs) == 0 {
-			logger.Errorf("%v: %s", errNoIPv4AddressFoundForHost, host)
+			logger.Errorf("%v: %s", errNoIPAddressFoundForHost, host)
 			break
 		}
 
 		hostIPs = append(hostIPs, currentHostIPs...)
 	}
 	return hostIPs
-}
-
-// isIPv4 checks if the given net.IP is an IPv4 address.
-func isIPv4(ip net.IP) bool {
-	return ip.To4() != nil
 }

--- a/ddnsallowlist_test.go
+++ b/ddnsallowlist_test.go
@@ -490,17 +490,25 @@ func TestResolveHosts(t *testing.T) {
 		{
 			desc:            "localhost",
 			hosts:           []string{"localhost"},
-			expectedHostIPs: []string{"127.0.0.1"},
+			expectedHostIPs: []string{"127.0.0.1", "::1"},
 		},
 		{
-			desc:            "single host",
-			hosts:           []string{"dns.google"},
-			expectedHostIPs: []string{"8.8.4.4", "8.8.8.8"},
+			desc:  "single host",
+			hosts: []string{"dns.google"},
+			expectedHostIPs: []string{
+				"2001:4860:4860::8844", "2001:4860:4860::8888",
+				"8.8.4.4", "8.8.8.8",
+			},
 		},
 		{
-			desc:            "multiple hosts",
-			hosts:           []string{"dns.google", "cloudflare-dns.com"},
-			expectedHostIPs: []string{"104.16.248.249", "104.16.249.249", "8.8.4.4", "8.8.8.8"},
+			desc:  "multiple hosts",
+			hosts: []string{"dns.google", "cloudflare-dns.com"},
+			expectedHostIPs: []string{
+				"104.16.248.249", "104.16.249.249",
+				"2001:4860:4860::8844", "2001:4860:4860::8888",
+				"2606:4700::6810:f8f9", "2606:4700::6810:f9f9",
+				"8.8.4.4", "8.8.8.8",
+			},
 		},
 	}
 

--- a/ddnsallowlist_test.go
+++ b/ddnsallowlist_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -511,38 +510,6 @@ func TestResolveHosts(t *testing.T) {
 			hostIPs := resolveHosts(*logger, tC.hosts)
 			sort.Strings(hostIPs)
 			assert.Equal(t, tC.expectedHostIPs, hostIPs)
-		})
-	}
-}
-
-func TestIsIPv4(t *testing.T) {
-	testCases := []struct {
-		desc     string
-		ip       net.IP
-		expected bool
-	}{
-		{
-			desc:     "IPv4",
-			ip:       net.ParseIP("1.2.3.4"),
-			expected: true,
-		},
-		{
-			desc:     "IPv6",
-			ip:       net.ParseIP("2001:01ce:cafe:0000:face:da7a:c0de:1337"),
-			expected: false,
-		},
-		{
-			desc:     "IPv6 short",
-			ip:       net.ParseIP("::1"),
-			expected: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tc.expected, isIPv4(tc.ip))
 		})
 	}
 }


### PR DESCRIPTION
Let IPv6 addresses be used in ddns-allowlist.

closes #22 