### PR TITLE
feat: allow IPv6 networkPrefix specification

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -17,4 +17,5 @@ testData:
   #   cloudflareDepth: 1
   #   excludedIPs:
   #     - 4.3.2.1
+  # allowedIPv6NetworkPrefix: 64
   lookupInterval: 300

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ http:
             cloudflareDepth: 1
             excludedIPs:
               - 4.3.2.1
+          # optional: allow IPv6 interface identifier based on given prefix
+          # this will skip the interface identifier validation (default: disabled)
+          allowedIPv6NetworkPrefix: 64
           # optional: lookup interval for DNS hosts (default: 5 min)
           lookupInterval: 60
 ```

--- a/ddnsallowlist_test.go
+++ b/ddnsallowlist_test.go
@@ -446,6 +446,39 @@ func TestServeHTTP(t *testing.T) {
 			},
 			expectedStatus: http.StatusForbidden,
 		},
+		{
+			desc: "allowed IPv6 with diff interface identifier",
+			config: &DdnsAllowListConfig{
+				SourceRangeHosts:         []string{"localhost"},
+				AllowedIPv6NetworkPrefix: 64,
+			},
+			req: &http.Request{
+				RemoteAddr: "00::11:22:33:44",
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			desc: "denied IPv6 with diff interface identifier",
+			config: &DdnsAllowListConfig{
+				SourceRangeHosts:         []string{"localhost"},
+				AllowedIPv6NetworkPrefix: 64,
+			},
+			req: &http.Request{
+				RemoteAddr: "abcd::11:22:33:44",
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			desc: "denied IPv6 without allowed interface identifier",
+			config: &DdnsAllowListConfig{
+				SourceRangeHosts:         []string{"localhost"},
+				AllowedIPv6NetworkPrefix: 128, // default 0 = 128 = not set
+			},
+			req: &http.Request{
+				RemoteAddr: "00::11:22:33:44",
+			},
+			expectedStatus: http.StatusForbidden,
+		},
 	}
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/github.com/traefik/traefik/pkg/config/dynamic/middlewares.go
+++ b/pkg/github.com/traefik/traefik/pkg/config/dynamic/middlewares.go
@@ -42,7 +42,7 @@ func (s *IPStrategy) Get() (ip.Strategy, error) {
 	}
 
 	if len(s.ExcludedIPs) > 0 {
-		checker, err := ip.NewChecker(s.ExcludedIPs, 0)
+		checker, err := ip.NewChecker(s.ExcludedIPs, ip.DefaultNetworkPrefixIPv6)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/github.com/traefik/traefik/pkg/config/dynamic/middlewares.go
+++ b/pkg/github.com/traefik/traefik/pkg/config/dynamic/middlewares.go
@@ -42,7 +42,7 @@ func (s *IPStrategy) Get() (ip.Strategy, error) {
 	}
 
 	if len(s.ExcludedIPs) > 0 {
-		checker, err := ip.NewChecker(s.ExcludedIPs)
+		checker, err := ip.NewChecker(s.ExcludedIPs, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/github.com/traefik/traefik/pkg/ip/checker.go
+++ b/pkg/github.com/traefik/traefik/pkg/ip/checker.go
@@ -14,7 +14,9 @@ import (
 	"strings"
 )
 
-const defaultNetworkPrefixIPv6 = 128
+// DefaultNetworkPrefixIPv6 defines the highest possible network prefix for IPv6 addresses.
+// When this is set the full IPv6 address needs to match the trusted IP.
+const DefaultNetworkPrefixIPv6 = 128
 
 var (
 	errCanNotParseIPaddress  = errors.New("can't parse IP from address")
@@ -54,13 +56,13 @@ func NewChecker(trustedIPs []string, networkPrefixIPv6 int) (*Checker, error) {
 		checker.authorizedIPsNet = append(checker.authorizedIPsNet, ipAddr)
 	}
 
-	if networkPrefixIPv6 < 0 || networkPrefixIPv6 > 128 {
+	if networkPrefixIPv6 < 0 || networkPrefixIPv6 > DefaultNetworkPrefixIPv6 {
 		return nil, fmt.Errorf("%w: %d", errInvalidIPv6NetPrefix, networkPrefixIPv6)
 	}
 	// If interface identifier prefix is not set, use default value.
 	// Otherwise if 0 is used all addresses will be allowed.
 	if networkPrefixIPv6 == 0 {
-		networkPrefixIPv6 = defaultNetworkPrefixIPv6
+		networkPrefixIPv6 = DefaultNetworkPrefixIPv6
 	}
 	checker.networkPrefixIPv6 = networkPrefixIPv6
 
@@ -114,7 +116,7 @@ func (ip *Checker) ContainsIP(addr net.IP) bool {
 		// This might be the case if resolved hostname is from a router.
 		// To allow all clients behind this routers network we need to filter only on network prefix.
 		// Check only runs on authorizedIPs and not authorizedNets because hostname will be an IP not network.
-		if ip.networkPrefixIPv6 != 128 && isIPv6(addr) && isIPv6(*authorizedIP) {
+		if ip.networkPrefixIPv6 != DefaultNetworkPrefixIPv6 && isIPv6(addr) && isIPv6(*authorizedIP) {
 			if isIPinNetwork(addr.String(), authorizedIP.String(), ip.networkPrefixIPv6) {
 				return true
 			}

--- a/pkg/github.com/traefik/traefik/pkg/ip/checker.go
+++ b/pkg/github.com/traefik/traefik/pkg/ip/checker.go
@@ -8,6 +8,7 @@ package ip
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/netip"
 	"strings"
@@ -144,19 +145,24 @@ func isIPv6(ip net.IP) bool {
 	return strings.Contains(ip.String(), ":")
 }
 
+// isIPinNetwork checks if a given net.IP is inside a network.
+// This function does not use the logger pkg because it would require to be passed to many functions.
 func isIPinNetwork(addr, networkAddr string, networkPrefix int) bool {
 	netAddr, err := netip.ParseAddr(networkAddr)
 	if err != nil {
+		log.Print("could not parse network address", err)
 		return false
 	}
 
 	network, err := netAddr.Prefix(networkPrefix)
 	if err != nil {
+		log.Print("could not get network address prefix", err)
 		return false
 	}
 
 	a, err := netip.ParseAddr(addr)
 	if err != nil {
+		log.Print("could not parse address", err)
 		return false
 	}
 

--- a/pkg/github.com/traefik/traefik/pkg/ip/checker.go
+++ b/pkg/github.com/traefik/traefik/pkg/ip/checker.go
@@ -13,10 +13,13 @@ import (
 	"strings"
 )
 
+const defaultNetworkPrefixIPv6 = 128
+
 var (
 	errCanNotParseIPaddress  = errors.New("can't parse IP from address")
 	errCIDRTrustedIPs        = errors.New("parsing CIDR trusted IPs")
 	errEmptyIP               = errors.New("empty IP address")
+	errInvalidIPv6NetPrefix  = errors.New("invalid IPv6 network prefix")
 	errMatchedNoneTrustedIPs = errors.New("matched none of the trusted IPs")
 	errNoTrustedIPsProvided  = errors.New("no trusted IPs provided")
 )
@@ -25,10 +28,12 @@ var (
 type Checker struct {
 	authorizedIPs    []*net.IP
 	authorizedIPsNet []*net.IPNet
+	// network prefix used to allow IPv6 addresses within the network (skips interface identifier)
+	networkPrefixIPv6 int
 }
 
 // NewChecker builds a new Checker given a list of CIDR-Strings to trusted IPs.
-func NewChecker(trustedIPs []string) (*Checker, error) {
+func NewChecker(trustedIPs []string, networkPrefixIPv6 int) (*Checker, error) {
 	if len(trustedIPs) == 0 {
 		return nil, errNoTrustedIPsProvided
 	}
@@ -47,6 +52,16 @@ func NewChecker(trustedIPs []string) (*Checker, error) {
 		}
 		checker.authorizedIPsNet = append(checker.authorizedIPsNet, ipAddr)
 	}
+
+	if networkPrefixIPv6 < 0 || networkPrefixIPv6 > 128 {
+		return nil, fmt.Errorf("%w: %d", errInvalidIPv6NetPrefix, networkPrefixIPv6)
+	}
+	// If interface identifier prefix is not set, use default value.
+	// Otherwise if 0 is used all addresses will be allowed.
+	if networkPrefixIPv6 == 0 {
+		networkPrefixIPv6 = defaultNetworkPrefixIPv6
+	}
+	checker.networkPrefixIPv6 = networkPrefixIPv6
 
 	return checker, nil
 }
@@ -93,6 +108,16 @@ func (ip *Checker) ContainsIP(addr net.IP) bool {
 		if authorizedIP.Equal(addr) {
 			return true
 		}
+
+		// Check if IPv6 address allowed with same network prefix but diff interface identifier.
+		// This might be the case if resolved hostname is from a router.
+		// To allow all clients behind this routers network we need to filter only on network prefix.
+		// Check only runs on authorizedIPs and not authorizedNets because hostname will be an IP not network.
+		if ip.networkPrefixIPv6 != 128 && isIPv6(addr) && isIPv6(*authorizedIP) {
+			if isIPinNetwork(addr.String(), authorizedIP.String(), ip.networkPrefixIPv6) {
+				return true
+			}
+		}
 	}
 
 	for _, authorizedNet := range ip.authorizedIPsNet {
@@ -112,4 +137,28 @@ func parseIP(addr string) (net.IP, error) {
 
 	ip := parsedAddr.As16()
 	return ip[:], nil
+}
+
+// isIPv4 checks if the given net.IP is an IPv4 address.
+func isIPv6(ip net.IP) bool {
+	return strings.Contains(ip.String(), ":")
+}
+
+func isIPinNetwork(addr, networkAddr string, networkPrefix int) bool {
+	netAddr, err := netip.ParseAddr(networkAddr)
+	if err != nil {
+		return false
+	}
+
+	network, err := netAddr.Prefix(networkPrefix)
+	if err != nil {
+		return false
+	}
+
+	a, err := netip.ParseAddr(addr)
+	if err != nil {
+		return false
+	}
+
+	return network.Contains(a)
 }

--- a/pkg/github.com/traefik/traefik/pkg/ip/checker_test.go
+++ b/pkg/github.com/traefik/traefik/pkg/ip/checker_test.go
@@ -1,0 +1,57 @@
+package ip
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsIPv6(t *testing.T) {
+	testCases := []struct {
+		addr     net.IP
+		expected bool
+	}{
+		{net.ParseIP("::1"), true},
+		{net.ParseIP("1234::4321"), true},
+		{net.ParseIP("1234:5678:9abc:def0:1234:5678:9abc:def0"), true},
+		{net.ParseIP("192.168.1.1"), false},
+		{net.ParseIP("invalid"), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.addr.String(), func(t *testing.T) {
+			t.Parallel()
+			if got := isIPv6(tc.addr); got != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestIsIPinNetwork(t *testing.T) {
+	testCases := []struct {
+		addr     string
+		network  string
+		prefix   int
+		expected bool
+	}{
+		{"2001:db8::1", "2001:db8::", 0, true},
+		{"2001:db8::1", "2001:db8::", 64, true},
+		{"2001:db8::1", "2001:db8::4321", 64, true},
+		{"2001:db8::1", "2001:abab::4321", 64, false},
+		{"2001:db8::1", "2001:db8::", 128, false},
+		{"aaaa:bbbb:cccc:dddd:1111:2222:3333:4444", "aaaa:bbbb:cccc:dddd:eeee:ffff:9999:8888", 64, true},
+		{"aaaa:bbbb:cccc:dddd:1111:2222:3333:4444", "aaaa:ffff:cccc:dddd:eeee:ffff:9999:8888", 64, false},
+		{"::1", "::2", DefaultNetworkPrefixIPv6, false},
+		{"10.10.10.10", "10.10.20.20", 16, true},
+		{"10.10.10.10", "10.10.20.20", 32, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.addr, func(t *testing.T) {
+			t.Parallel()
+			if got := isIPinNetwork(tc.addr, tc.network, tc.prefix); got != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add support to allow different IPv6 interface identifier by same network prefix.

The problem this PR solves is as follows:
When a router used to fetch the hostname from (which should be the common way this middleware is used) the IPv6 address includes the full IP to the router (with _interface identifier_).
If a device from the network behind this router will access the protected website the _network prefix_ will be the same but interface identifier differs.

Therefore we need some validation if the IPv6 address is within the same network.
With this change the user can specify an prefix (1-128) in which the network prefix will be accepted (subnetmask).

The default should be `64` which will commonly split network prefix from interface identifier:

```yaml
  middlewares:
    ddns-allowlist-router:
      plugin:
        ddns-allowlist:
          allowedIPv6NetworkPrefix: 64
```

- [x] add tests

closes #41