### PR TITLE
chore: use same ports for docker-compose as for k8s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     extra_hosts:
     - "dockerhost=192.168.65.1"
     ports:
-    - "80:80"
-    - "8080:8080"
+    - "8080:80"
+    - "9000:8080"
     volumes:
     - "/var/run/docker.sock:/var/run/docker.sock:ro"
     - "./:/plugins-local/src/github.com/taskmedia/ddns-allowlist:ro"


### PR DESCRIPTION
Use same ports for docker-compose as for k8s