### PR TITLE
chore: add trace level to output incoming request

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ http:
     ddns-allowlist-router:
       plugin:
         ddns-allowlist:
-          # optional: log level for the plugin (allowed: ERROR, INFO, DEBUG, default: ERROR)
+          # optional: log level for the plugin (allowed: ERROR, INFO, DEBUG, TRACE - default: ERROR)
           logLevel: ERROR
           # hosts to dynamically add to allowlist via DNS lookup
           sourceRangeHosts:

--- a/ddnsallowlist.go
+++ b/ddnsallowlist.go
@@ -147,7 +147,7 @@ func (dal *ddnsAllowLister) updateTrustedIPs() error {
 func (dal *ddnsAllowLister) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	logger := dal.logger
 	logger.Debug("Serving middleware")
-	logger.Trace("Incoming request: %+v", req)
+	logger.Tracef("Incoming request: %+v", req)
 
 	// Check if the trusted IPs need to be updated
 	dal.mu.Lock()

--- a/ddnsallowlist.go
+++ b/ddnsallowlist.go
@@ -147,6 +147,7 @@ func (dal *ddnsAllowLister) updateTrustedIPs() error {
 func (dal *ddnsAllowLister) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	logger := dal.logger
 	logger.Debug("Serving middleware")
+	logger.Trace("Incoming request: %+v", req)
 
 	// Check if the trusted IPs need to be updated
 	dal.mu.Lock()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,14 +28,14 @@ services:
     - "traefik.http.routers.whoami-allow.entrypoints=web"
     - "traefik.http.routers.whoami-allow.middlewares=ddnsal-allow@docker"
     - "traefik.http.middlewares.ddnsal-allow.plugin.ddns-allowlist.sourceRangeHosts=localhost,dockerhost"
-    - "traefik.http.middlewares.ddnsal-allow.plugin.ddns-allowlist.logLevel=debug"
+    - "traefik.http.middlewares.ddnsal-allow.plugin.ddns-allowlist.logLevel=TRACE"
     - "traefik.http.middlewares.ddnsal-allow.plugin.ddns-allowlist.lookupInterval=15"
     # deny
     - "traefik.http.routers.whoami-deny.rule=Host(`deny.whoami.localhost`)"
     - "traefik.http.routers.whoami-deny.entrypoints=web"
     - "traefik.http.routers.whoami-deny.middlewares=ddnsal-deny@docker"
     - "traefik.http.middlewares.ddnsal-deny.plugin.ddns-allowlist.sourceRangeHosts=localhost,dns.google"
-    - "traefik.http.middlewares.ddnsal-deny.plugin.ddns-allowlist.logLevel=debug"
+    - "traefik.http.middlewares.ddnsal-deny.plugin.ddns-allowlist.logLevel=TRACE"
     - "traefik.http.middlewares.ddnsal-deny.plugin.ddns-allowlist.lookupInterval=15"
     # # allow ipList
     # - "traefik.http.routers.whoami-allowip.rule=Host(`allow-ip.whoami.localhost`)"

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -15,10 +15,12 @@ import (
 const (
 	prefixInfo  = colorGreen + "INF" + colorReset
 	prefixTrace = colorBlue + "TRC" + colorReset
+	delimiter   = colorCyan + ">" + colorReset
 	colorReset  = "\033[0m"
 	colorGray   = "\033[90m"
 	colorGreen  = "\033[32m"
 	colorBlue   = "\033[34m"
+	colorCyan   = "\033[36m"
 )
 
 // Logger will log messages with context.
@@ -46,7 +48,7 @@ func NewLogger(_logLevel, middleware, middlewareType string) *Logger {
 
 	logger := &Logger{
 		_trace: func(args ...interface{}) {
-			prefixArgs := append([]interface{}{getTimestamp(), prefixTrace, ">"}, args...)
+			prefixArgs := append([]interface{}{getTimestamp(), prefixTrace, delimiter}, args...)
 			//nolint:errcheck
 			fmt.Fprintln(os.Stdout, prefixArgs...)
 		},
@@ -54,7 +56,7 @@ func NewLogger(_logLevel, middleware, middlewareType string) *Logger {
 			fmt.Println(args...)
 		},
 		_info: func(args ...interface{}) {
-			prefixArgs := append([]interface{}{getTimestamp(), prefixInfo, ">"}, args...)
+			prefixArgs := append([]interface{}{getTimestamp(), prefixInfo, delimiter}, args...)
 			//nolint:errcheck
 			fmt.Fprintln(os.Stdout, prefixArgs...)
 		},
@@ -62,7 +64,7 @@ func NewLogger(_logLevel, middleware, middlewareType string) *Logger {
 			log.Println(args...)
 		},
 		_tracef: func(format string, args ...interface{}) {
-			f := getTimestamp() + " " + prefixTrace + " > " + format + "\n"
+			f := getTimestamp() + " " + prefixTrace + " " + delimiter + " " + format + "\n"
 			//nolint:errcheck
 			fmt.Fprintf(os.Stdout, f, args...)
 		},
@@ -70,7 +72,7 @@ func NewLogger(_logLevel, middleware, middlewareType string) *Logger {
 			fmt.Printf(format+"\n", args...)
 		},
 		_infof: func(format string, args ...interface{}) {
-			f := getTimestamp() + " " + prefixInfo + " > " + format + "\n"
+			f := getTimestamp() + " " + prefixInfo + " " + delimiter + " " + format + "\n"
 			//nolint:errcheck
 			fmt.Fprintf(os.Stdout, f, args...)
 		},

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -165,7 +165,7 @@ func (l *Logger) Error(args ...interface{}) {
 
 // Tracef prints an debug log.
 func (l *Logger) Tracef(format string, args ...interface{}) {
-	l.logWithContextf(l._debugf, format, args...)
+	l.logWithContextf(l._tracef, format, args...)
 }
 
 // Debugf prints an debug log.

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -13,19 +13,23 @@ import (
 )
 
 const (
-	prefixInfo = colorGreen + "INF" + colorReset
-	colorReset = "\033[0m"
-	colorGray  = "\033[90m"
-	colorGreen = "\033[32m"
+	prefixInfo  = colorGreen + "INF" + colorReset
+	prefixTrace = colorBlue + "TRC" + colorReset
+	colorReset  = "\033[0m"
+	colorGray   = "\033[90m"
+	colorGreen  = "\033[32m"
+	colorBlue   = "\033[34m"
 )
 
 // Logger will log messages with context.
 type Logger struct {
-	_info   func(args ...interface{})
+	_trace  func(args ...interface{})
 	_debug  func(args ...interface{})
+	_info   func(args ...interface{})
 	_error  func(args ...interface{})
-	_infof  func(format string, args ...interface{})
+	_tracef func(format string, args ...interface{})
 	_debugf func(format string, args ...interface{})
+	_infof  func(format string, args ...interface{})
 	_errorf func(format string, args ...interface{})
 	context map[string]interface{}
 }
@@ -41,6 +45,11 @@ func NewLogger(_logLevel, middleware, middlewareType string) *Logger {
 	log.SetFlags(0)
 
 	logger := &Logger{
+		_trace: func(args ...interface{}) {
+			prefixArgs := append([]interface{}{getTimestamp(), prefixTrace, ">"}, args...)
+			//nolint:errcheck
+			fmt.Fprintln(os.Stdout, prefixArgs...)
+		},
 		_debug: func(args ...interface{}) {
 			fmt.Println(args...)
 		},
@@ -51,6 +60,11 @@ func NewLogger(_logLevel, middleware, middlewareType string) *Logger {
 		},
 		_error: func(args ...interface{}) {
 			log.Println(args...)
+		},
+		_tracef: func(format string, args ...interface{}) {
+			f := getTimestamp() + " " + prefixTrace + " > " + format + "\n"
+			//nolint:errcheck
+			fmt.Fprintf(os.Stdout, f, args...)
 		},
 		_debugf: func(format string, args ...interface{}) {
 			fmt.Printf(format+"\n", args...)
@@ -85,6 +99,10 @@ func NewLogger(_logLevel, middleware, middlewareType string) *Logger {
 		logger._debugf = disableLogf
 		fallthrough
 	case "debug":
+		// disable trace logging
+		logger._trace = disableLog
+		logger._tracef = disableLogf
+	case "trace":
 		// nothing disabled for most detailed logging
 	default:
 		// disable all logging except error
@@ -92,6 +110,8 @@ func NewLogger(_logLevel, middleware, middlewareType string) *Logger {
 		logger._infof = disableLogf
 		logger._debug = disableLog
 		logger._debugf = disableLogf
+		logger._trace = disableLog
+		logger._tracef = disableLogf
 	}
 
 	return logger
@@ -123,6 +143,11 @@ func (l *Logger) logWithContextf(logFunc func(format string, args ...interface{}
 	logFunc(format, args...)
 }
 
+// Trace prints an debug log.
+func (l *Logger) Trace(args ...interface{}) {
+	l.logWithContext(l._trace, args...)
+}
+
 // Debug prints an debug log.
 func (l *Logger) Debug(args ...interface{}) {
 	l.logWithContext(l._debug, args...)
@@ -136,6 +161,11 @@ func (l *Logger) Info(args ...interface{}) {
 // Error prints an error log.
 func (l *Logger) Error(args ...interface{}) {
 	l.logWithContext(l._error, args...)
+}
+
+// Tracef prints an debug log.
+func (l *Logger) Tracef(format string, args ...interface{}) {
+	l.logWithContextf(l._debugf, format, args...)
 }
 
 // Debugf prints an debug log.

--- a/tests/k8s/resources/allow.yml
+++ b/tests/k8s/resources/allow.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   plugin:
     ddns-allowlist:
-      logLevel: DEBUG
+      logLevel: TRACE
       sourceRangeHosts:
       - localhost
       # sourceRangeIps:

--- a/tests/k8s/resources/deny.yml
+++ b/tests/k8s/resources/deny.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   plugin:
     ddns-allowlist:
-      logLevel: DEBUG
+      logLevel: TRACE
       sourceRangeHosts:
       - dns.google
       # sourceRangeIps:


### PR DESCRIPTION
For better debugging / logging the level trace was added to the logger.
A first output for this log level was added: log incoming request.