### PR TITLE
fix(test): change traefik web port to 8000

### DIFF
--- a/tests/k8s/traefik-values.yml
+++ b/tests/k8s/traefik-values.yml
@@ -38,7 +38,7 @@ ports:
     expose:
       default: true
   web:
-    exposedPort: 8080
+    exposedPort: 8000
   websecure:
     expose:
       default: false


### PR DESCRIPTION
change traefik web port to `8000`.

Port `8080` now is used for websecure - need to change port when using newer traefik version.